### PR TITLE
Use `is_template` context var to control if workflow runs

### DIFF
--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -40,7 +40,7 @@ jobs:
     # 3. This is the first workflow run on the repository
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ github.repository_owner != 'InfomagnusOrg' 
+    if: ${{ !github.event.repository.is_template 
         && needs.get_current_step.outputs.current_step == 0
         && github.run_number == 1 }}
 

--- a/.github/workflows/1-configure-label-based-job.yml
+++ b/.github/workflows/1-configure-label-based-job.yml
@@ -44,7 +44,7 @@ jobs:
     # 2. The STEP is currently 1 (see update-step.sh)
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ github.repository_owner != 'TBD-organization'
+    if: ${{ !github.event.repository.is_template
         && needs.get_current_step.outputs.current_step == 1 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows

--- a/.github/workflows/2-setup-azure-environment.yml
+++ b/.github/workflows/2-setup-azure-environment.yml
@@ -44,7 +44,7 @@ jobs:
     # 2. The STEP is currently 3 (see update-step.sh)
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ github.repository_owner != 'TBD-organization'
+    if: ${{ !github.event.repository.is_template
         && needs.get_current_step.outputs.current_step == 2 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows

--- a/.github/workflows/3-spinup-environment.yml
+++ b/.github/workflows/3-spinup-environment.yml
@@ -44,7 +44,7 @@ jobs:
     # 2. The STEP is currently 4 (see update-step.sh)
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ github.repository_owner != 'TBD-organization'
+    if: ${{ !github.event.repository.is_template
         && needs.get_current_step.outputs.current_step == 3 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows

--- a/.github/workflows/4-deploy-to-staging-environment.yml
+++ b/.github/workflows/4-deploy-to-staging-environment.yml
@@ -46,7 +46,7 @@ jobs:
     # 
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ github.repository_owner != 'TBD-organization'
+    if: ${{ !github.event.repository.is_template
         && needs.get_current_step.outputs.current_step == 4 }}
 
     steps:

--- a/.github/workflows/5-deploy-to-prod-environment.yml
+++ b/.github/workflows/5-deploy-to-prod-environment.yml
@@ -43,7 +43,7 @@ jobs:
     # 2. The STEP is currently 4 (see update-step.sh)
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ github.repository_owner != 'TBD-organization'
+    if: ${{ !github.event.repository.is_template
         && needs.get_current_step.outputs.current_step == 5 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows

--- a/.github/workflows/6-destroy-azure-environment.yml
+++ b/.github/workflows/6-destroy-azure-environment.yml
@@ -43,7 +43,7 @@ jobs:
     # 2. The STEP is currently 4 (see update-step.sh)
     # Reference https://docs.github.com/en/actions/learn-github-actions/contexts
     # Reference https://docs.github.com/en/actions/learn-github-actions/expressions
-    if: ${{ github.repository_owner != 'TBD-organization'
+    if: ${{ !github.event.repository.is_template
         && needs.get_current_step.outputs.current_step == 6 }}
 
     # We'll run Ubuntu for performance instead of Mac or Windows


### PR DESCRIPTION
### Why:

Use `if: ${{ !github.event.repository.is_template ...` instead of `if: ${{ github.repository_owner != 'TBD-organization' ...` to control if the workflow runs. This brings the workflows inline with the skills [template-template workflow](https://github.com/skills/template-template/blob/4eecba3b9abecb6a06fcc7ef5ad7a3cfb105c8cf/.github/workflows/0-start.yml#L29).


### What's being changed:

* Change `github.repository_owner != 'TBD-organization'` to `!github.event.repository.is_template` in each workflow file.

### Check off the following:

- [ ] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
