### PR TITLE
[WIP] Fix step 2 missing workflow

### DIFF
--- a/.github/example-workflows/deploy-prod.yml
+++ b/.github/example-workflows/deploy-prod.yml
@@ -1,0 +1,88 @@
+# Deploy application to production environment
+# .github/example-workflows/deploy-prod.yml
+name: Deploy to production
+
+# Add triggers here
+
+env:
+  IMAGE_REGISTRY_URL: ghcr.io
+  DOCKER_IMAGE_NAME: <username>-azure-ttt
+  AZURE_WEBAPP_NAME: <username>-ttt-app
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: npm install and build webpack
+        run: |
+          npm install
+          npm run build
+      - uses: actions/upload-artifact@main
+        with:
+          name: webpack artifacts
+          path: public/
+          
+  Build-Docker-Image:
+    runs-on: ubuntu-latest
+    needs: build
+    name: Build image and store in GitHub Container Registry
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download built artifact
+        uses: actions/download-artifact@main
+        with:
+          name: webpack artifacts
+          path: public
+          
+      - name: Log in to GHCR
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ${{ env.IMAGE_REGISTRY_URL }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.7.0
+        with:
+          images: ${{env.IMAGE_REGISTRY_URL}}/${{ github.repository }}/${{env.DOCKER_IMAGE_NAME}}
+          tags: |
+            type=sha,format=long,prefix=
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.10.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  Deploy-to-Azure:
+    runs-on: ubuntu-latest
+    needs: Build-Docker-Image
+    name: Deploy app container to Azure
+    steps:
+      - name: "Login via Azure CLI"
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: azure/docker-login@v1
+        with:
+          login-server: ${{env.IMAGE_REGISTRY_URL}}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy web app container
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{env.AZURE_WEBAPP_NAME}}
+          images: ${{env.IMAGE_REGISTRY_URL}}/${{ github.repository }}/${{env.DOCKER_IMAGE_NAME}}:${{github.sha}}
+
+      - name: Azure logout
+        run: |
+          az logout

--- a/.github/example-workflows/deploy-staging.yml
+++ b/.github/example-workflows/deploy-staging.yml
@@ -1,0 +1,92 @@
+# Deploy application to staging environment
+# .github/example-workflows/deploy-staging.yml
+name: Deploy to staging
+
+on: 
+  pull_request:
+    types: [labeled]
+
+env:
+  IMAGE_REGISTRY_URL: ghcr.io
+  DOCKER_IMAGE_NAME: <username>-azure-ttt
+  AZURE_WEBAPP_NAME: <username>-ttt-app
+
+jobs:
+  build:
+    if: contains(github.event.pull_request.labels.*.name, 'stage')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: npm install and build webpack
+        run: |
+          npm install
+          npm run build
+      - uses: actions/upload-artifact@main
+        with:
+          name: webpack artifacts
+          path: public/
+
+  Build-Docker-Image:
+    runs-on: ubuntu-latest
+    needs: build
+    name: Build image and store in GitHub Container Registry
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download built artifact
+        uses: actions/download-artifact@main
+        with:
+          name: webpack artifacts
+          path: public
+          
+      - name: Log in to GHCR
+        uses: docker/login-action@v1.14.1
+        with:
+          registry: ${{ env.IMAGE_REGISTRY_URL }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.7.0
+        with:
+          images: ${{env.IMAGE_REGISTRY_URL}}/${{ github.repository }}/${{env.DOCKER_IMAGE_NAME}}
+          tags: |
+            type=sha,format=long,prefix=
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.10.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  Deploy-to-Azure:
+    runs-on: ubuntu-latest
+    needs: Build-Docker-Image
+    name: Deploy app container to Azure
+    steps:
+      - name: "Login via Azure CLI"
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - uses: azure/docker-login@v1
+        with:
+          login-server: ${{env.IMAGE_REGISTRY_URL}}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy web app container
+        uses: azure/webapps-deploy@v2
+        with:
+          app-name: ${{env.AZURE_WEBAPP_NAME}}
+          images: ${{env.IMAGE_REGISTRY_URL}}/${{ github.repository }}/${{env.DOCKER_IMAGE_NAME}}:${{ github.sha }}
+
+      - name: Azure logout
+        run: |
+          az logout

--- a/.github/example-workflows/spinup-destroy.yml
+++ b/.github/example-workflows/spinup-destroy.yml
@@ -1,0 +1,69 @@
+# Jobs used to create and destroy Azure resources
+# .github/example-workflows/spinup-destroy.yml
+name: Configure Azure environment
+ 
+on:
+ pull_request:
+   types: [labeled]
+ 
+env:
+ IMAGE_REGISTRY_URL: ghcr.io
+ AZURE_RESOURCE_GROUP: cd-with-actions
+ AZURE_APP_PLAN: actions-ttt-deployment
+ AZURE_LOCATION: '"Central US"'
+ AZURE_WEBAPP_NAME: <username>-ttt-app
+ 
+jobs:
+ setup-up-azure-resources:
+   runs-on: ubuntu-latest
+ 
+   if: contains(github.event.pull_request.labels.*.name, 'spin up environment')
+ 
+   steps:
+     - name: Checkout repository
+       uses: actions/checkout@v2
+ 
+     - name: Azure login
+       uses: azure/login@v1
+       with:
+         creds: ${{ secrets.AZURE_CREDENTIALS }}
+ 
+     - name: Create Azure resource group
+       if: success()
+       run: |
+         az group create --location ${{env.AZURE_LOCATION}} --name ${{env.AZURE_RESOURCE_GROUP}} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+ 
+     - name: Create Azure app service plan
+       if: success()
+       run: |
+         az appservice plan create --resource-group ${{env.AZURE_RESOURCE_GROUP}} --name ${{env.AZURE_APP_PLAN}} --is-linux --sku F1 --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+ 
+     - name: Create webapp resource
+       if: success()
+       run: |
+         az webapp create --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --plan ${{ env.AZURE_APP_PLAN }} --name ${{ env.AZURE_WEBAPP_NAME }}  --deployment-container-image-name nginx --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+ 
+     - name: Configure webapp to use GHCR
+       if: success()
+       run: |
+         az webapp config container set --docker-custom-image-name nginx --docker-registry-server-password ${{secrets.CR_PAT}} --docker-registry-server-url https://${{env.IMAGE_REGISTRY_URL}} --docker-registry-server-user ${{github.actor}} --name ${{ env.AZURE_WEBAPP_NAME }} --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}}
+ 
+ destroy-azure-resources:
+   runs-on: ubuntu-latest
+ 
+   if: contains(github.event.pull_request.labels.*.name, 'destroy environment')
+ 
+   steps:
+     - name: Checkout repository
+       uses: actions/checkout@v2
+ 
+     - name: Azure login
+       uses: azure/login@v1
+       with:
+         creds: ${{ secrets.AZURE_CREDENTIALS }}
+ 
+     - name: Destroy Azure environment
+       if: success()
+       run: |
+         az group delete --name ${{env.AZURE_RESOURCE_GROUP}} --subscription ${{secrets.AZURE_SUBSCRIPTION_ID}} --yes
+

--- a/.github/script/create-workflow.sh
+++ b/.github/script/create-workflow.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Make sure this file is executable
-# chmod a+x .github/script/create-workflow-pr.sh
+# chmod a+x .github/script/create-workflow.sh
 
 git config user.name github-actions
 git config user.email github-actions@github.com

--- a/.github/script/create-workflow.sh
+++ b/.github/script/create-workflow.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Make sure this file is executable
+# chmod a+x .github/script/create-workflow-pr.sh
+
+git config user.name github-actions
+git config user.email github-actions@github.com
+
+workflow_filename=$(basename ${WORKFLOW_PATH})
+
+echo "Make sure we are on the main branch"
+git checkout main
+
+echo "Create new branch or checkout if it exists"
+git switch -C $BRANCH
+
+echo "Copy example workflow into .github/workflows/"
+cp $WORKFLOW_PATH .github/workflows/
+
+echo "In workflow, replace <username> with GitHub repository owner"
+sed -i -r "s/<username>/$REPO_OWNER/g" .github/workflows/$workflow_filename
+
+echo "Commit the file, and push to new branch"
+git config user.name github-actions
+git config user.email github-actions@github.com
+git add .github/workflows/$workflow_filename
+git commit --message="Added $workflow_filename"
+git push origin $BRANCH

--- a/.github/workflows/2-setup-azure-environment.yml
+++ b/.github/workflows/2-setup-azure-environment.yml
@@ -76,6 +76,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Create azure-configuration branch and add spinup-destroy.yml file to it
+      - name: Create azure-configuration branch
+        run: ./.github/script/create-workflow.sh
+        env:
+          BRANCH: azure-configuration
+          WORKFLOW_PATH: .github/example-workflows/spinup-destroy.yml
+
       # Create pull request from azure-configuration branch to set up next step
       - name: Create azure-configuration pull request 
         run: ./.github/script/create-workflow-pr.sh

--- a/.github/workflows/2-setup-azure-environment.yml
+++ b/.github/workflows/2-setup-azure-environment.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Create azure-configuration branch
         run: ./.github/script/create-workflow.sh
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: azure-configuration
           WORKFLOW_PATH: .github/example-workflows/spinup-destroy.yml
 


### PR DESCRIPTION
Previous commits removed `spinup-destroy.yml` workflow and bash scripts that setup a PR that is referenced in Step 3. Step 2 workflow needs a new branch `azure-configuration`, and workflow `spinup-destroy.yml` created before it can open a new PR.

### Why:

- [~~Closes~~] #11 
- [Help on Step 1 Activity 2 | continuous-delivery-azure](https://github.com/orgs/skills/discussions/14) discussion

### What's being changed:

- re-add `.github/example-workflows` dir
- add step to `.github/workflows/2-setup-azure-environment.yml` to run script file
- add bash script file to create branch, copy workflow file, and push branch

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).

### ToDo

- [ ] either; add instructions for creating a `workflow` scoped PAT, or add instructions for learner to create the workflow file
